### PR TITLE
Issue #54: ston repository needs to be cloned as well as tode repo. ston...

### DIFF
--- a/bin/windows/createWindowsTodeImage
+++ b/bin/windows/createWindowsTodeImage
@@ -9,17 +9,18 @@
 #
 # Examples
 #   createTodeImage -h
-#   createTodeImage -p _0 c:/tode/repository
-#   createTodeImage c:/tode/repository
+#   createTodeImage -p _0 c:/tode c:/ston
+#   createTodeImage c:/tode c:/ston
 #
 #=========================================================================
 
 # help function
 function display_help() {
   echo ""
-  echo "USAGE: $(basename $0) [-h] [-p <postfix] <tode-repository-path>"
-  echo "Create the tODE client image loading tODE from the specified repository."
-  echo "Used for running pharo-based scripts and for running the tODE client UI."
+  echo "USAGE: $(basename $0) [-h] [-p <postfix] <tode-repository-path> <ston-repository-path>"
+  echo "Create the tODE client image loading tODE and ston from the specified"
+  echo "repositories. Used for running pharo-based scripts and for running the"
+  echo "tODE client UI."
   echo ""
   echo "OPTIONS"
   echo "  -h "
@@ -30,8 +31,8 @@ function display_help() {
   echo ""
   echo "EXAMPLES"
   echo "  $(basename $0) -h"
-  echo "  $(basename $0) -p _0 c:/tode/repository"
-  echo "  $(basename $0) c:/tode/repository"
+  echo "  $(basename $0) -p _0 c:/tode c:/ston"
+  echo "  $(basename $0) c:/tode c:/ston"
   echo ""  
 }
 
@@ -56,7 +57,13 @@ if [ "$1x" = "x" ] ; then
   echo "<tode-repository-path> missing"
   exit 1
 fi
-repo_path="$1"
+tode_path="$1"
+
+if [ "$2x" = "x" ] ; then
+  echo "<ston-repository-path> missing"
+  exit 1
+fi
+ston_path="$2"
 
 if [ "${GS_HOME}x" = "x" ] ; then
   echo "the GS_HOME environment variable needs to be defined"
@@ -76,10 +83,14 @@ $pharo/Pharo.exe --headless $pharo/Pharo3.0.image save todeClientTmp
 
 cat - > $pharo/todeLoad.st << EOF
 [ | metacello string repoPath |
-  "Windows path limitations force us to put Tode outside GS_HOME."
+  "Windows path limitations force us to put Tode and ston outside GS_HOME."
   Metacello new
     baseline: 'Tode';
-    repository: 'filetree://', '$repo_path';
+    repository: 'filetree://', '${tode_path}/repository';
+    lock.
+  Metacello new
+    baseline: 'Ston';
+    repository: 'filetree://', '${ston_path}/repository';
     lock.
   string := '$GS_HOME/repository'.
   repoPath := (string copyFrom: 2 to: 2), ':', (string copyFrom: 3 to: string size).
@@ -89,7 +100,6 @@ cat - > $pharo/todeLoad.st << EOF
     repository: 'filetree://', repoPath.
   metacello copy get.
   metacello 
-    onConflict: [:ex | ex disallow];
     load ]
       on: Warning
       do: [:ex | Transcript cr; show: ex description ].

--- a/bin/windows/installWindowsClient
+++ b/bin/windows/installWindowsClient
@@ -17,18 +17,18 @@
 # help function
 function display_help() {
   echo ""
-  echo "USAGE: $(basename $0) [-h] <gemstone-version> <tode-repository-path>"
+  echo "USAGE: $(basename $0) [-h] <gemstone-version> <tode-repository-path> <ston-repository-path>"
   echo "Install GemStone (specified gs-version), Pharo, build tODE client"
   echo "image and launch the tODE client."
-  echo "<tode-repository-path> must be explicitly specified to circumvent"
-  echo "several problems."
+  echo "<tode-repository-path> and <ston-repository-path> must be explicitly"
+  echo "specified to circumvent several problems."
   echo ""
   echo "OPTIONS"
   echo "  -h display help"
   echo ""
   echo "EXAMPLES"
   echo "   $(basename $0) -h"
-  echo "   $(basename $0) 3.2.1 c:/tode/repository"
+  echo "   $(basename $0) 3.2.3 c:/tode c:/ston"
   echo ""
 }
 
@@ -55,7 +55,14 @@ if [ "$2x" = "x" ] ; then
   display_help
   exit 1
 fi
-repo_path=$2
+
+if [ "$3x" = "x" ] ; then
+  display_help
+  exit 1
+fi
+
+tode_path="$2"
+ston_path="$3"
 
 if [ "${GS_HOME}x" = "x" ] ; then
   echo "the GS_HOME environment variable needs to be defined"
@@ -68,7 +75,7 @@ if [[ $? != 0 ]] ; then exit 1; fi
 $GS_HOME/bin/windows/installWindowsPharo
 if [[ $? != 0 ]] ; then exit 1; fi
 
-$GS_HOME/bin/windows/createWindowsTodeImage $repo_path
+$GS_HOME/bin/windows/createWindowsTodeImage "$tode_path" "$ston_path"
 if [[ $? != 0 ]] ; then exit 1; fi
 
 $GS_HOME/bin/windows/todeWindowsClient

--- a/docs/windowsClientInstallation.md
+++ b/docs/windowsClientInstallation.md
@@ -14,25 +14,31 @@
    export PATH=$GS_HOME/bin/windows:$PATH
    ```
 
-5. Using the bash shell, clone the [tode project][3] to your local disk to the root of your C: drive. 
-   We're manually cloning tODE to avoid hitting the 256 character path limit for Windows and rooting the repository at the C: keeps the longest paths in tODE out of trouble:
+5. Using the bash shell, clone the [tode][3] and [ston][8] projects to the root of your C: drive. 
+   We're manually cloning `tODE` to avoid hitting the 256 character path limit for Windows and rooting the repository at the C: keeps the longest paths in tODE out of trouble. The `ston` project needs to be cloned, because the version of Metacello ppresent in the standard Pharo3.0 image, cannot download projects directly from **GitHub**:
 
    ```Shell
    cd /c
-   git clone https://github.com/GsDevKit/gsDevKitHome.git
+   git clone https://github.com/dalehenrich/tode.git
+   cd tode
+   git checkout master
+   cd /c
+   git clone https://github.com/dalehenrich/ston.git
+   cd ston
+   git checkout pharo
    ```
 
 5. Checkout your branch of the [gsDevKitHome project][2]:
 
    ```Shell
-   cd $GS_HOME/gsDevKitHome
+   cd $GS_HOME
    git checkout -b  <your branch name>
    ```
 
 6. Install GemStone/S (for GCI library files) and Pharo, build the tODE client image and launch the tODE client. The GemStone version that specify in the following should match the version installed on your server machine:
 
    ```Shell
-   installWindowsClient 3.2.1 c:/tode/repository
+   installWindowsClient 3.2.3 c:/tode/repository c:/ston/repository
    ```
 
 4. Once the tODE client image comes up, you need to edit the session description for your stones using the `tODE edit` menu:
@@ -61,4 +67,4 @@ Here's the [list of scripts that can be used on the client machine][7].
 [5]: images/descriptionWorkspace.png
 [6]: ../bin/stones
 [7]: ../bin/windows/README.md#gsdevkit-windows-client-scripts
-
+[8]: https://github.com/dalehenrich/ston


### PR DESCRIPTION
... repo needs to be cloned, because the standard github download in the current pharo3.0 image, requires that the directory /tmp exist for windows ... that Metacello bug was fixed a while back, but pharo3.0 has not updated to the latest Metacello